### PR TITLE
Improve operator for MySQL upgrade

### DIFF
--- a/cmd/bootstrap/async_replication.go
+++ b/cmd/bootstrap/async_replication.go
@@ -274,6 +274,10 @@ func selectDonor(ctx context.Context, fqdn, primary string, replicas []string) (
 }
 
 func isCloneRequired(file string) (bool, error) {
+	if !getCloneRequiredFromEnv() {
+		return false, nil
+	}
+
 	_, err := os.Stat(file)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -291,6 +295,25 @@ func createCloneLock(file string) error {
 }
 
 func deleteCloneLock(file string) error {
-	err := os.Remove(file)
-	return errors.Wrapf(err, "remove %s", file)
+	if err := os.Remove(file); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return errors.Wrapf(err, "remove %s", file)
+	}
+
+	return nil
+}
+
+func getCloneRequiredFromEnv() bool {
+	s, ok := os.LookupEnv("CLONE_REQUIRED_ON_ASYNC_CLUSTER")
+	if !ok {
+		return true
+	}
+
+	if s == "true" {
+		return true
+	}
+
+	return false
 }

--- a/pkg/controller/ps/upgrade.go
+++ b/pkg/controller/ps/upgrade.go
@@ -2,7 +2,10 @@ package ps
 
 import (
 	"context"
+	"fmt"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"os"
+	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
@@ -95,12 +98,35 @@ func (r *PerconaServerMySQLReconciler) smartUpdate(ctx context.Context, sts *app
 			continue
 		}
 
-		log.Info("apply changes to secondary pod", "pod", pod.Name)
-
 		if pod.ObjectMeta.Labels[controllerRevisionHash] == sts.Status.UpdateRevision {
 			log.Info("pod updated", "pod", pod.Name)
-			continue
+
+			syncTimeout, err := getReplicaSyncTimeout()
+			if err != nil {
+				log.Error(err, "REPLICATION_SYNC_WAIT_TIME_ON_UPGRADE is unusable")
+				continue
+			}
+
+			if syncTimeout == 0 {
+				continue
+			}
+
+			syncTimeoutDuration := time.Duration(syncTimeout)
+			readyCondition := findPodReadyCondition(&pod)
+			if readyCondition == nil {
+				return nil
+			}
+			timeSincePodReady := time.Since(readyCondition.LastTransitionTime.Time)
+
+			log.Info("The next pod updat will be triggered soon.", "time", syncTimeoutDuration*time.Minute-timeSincePodReady)
+			if timeSincePodReady >= syncTimeoutDuration*time.Minute {
+				continue
+			}
+
+			return nil
 		}
+
+		log.Info("apply changes to secondary pod", "pod", pod.Name)
 
 		return deletePod(ctx, r.Client, &pod, currentSet)
 	}
@@ -207,9 +233,36 @@ func deletePod(ctx context.Context, cli client.Client, pod *corev1.Pod, sts *app
 
 		if s.Status.ReadyReplicas == s.Status.Replicas {
 			return errors.New("sts.Status.readyReplicas not updated")
-
 		}
 
 		return nil
 	})
+}
+
+func getReplicaSyncTimeout() (uint32, error) {
+	s, ok := os.LookupEnv("REPLICATION_SYNC_WAIT_TIME_ON_UPGRADE")
+	if !ok {
+		return 0, nil
+	}
+
+	readTimeout, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("REPLICATION_SYNC_WAIT_TIME_ON_UPGRADE must be positive number. Error - %v", err)
+	}
+
+	if readTimeout < 0 {
+		return 0, fmt.Errorf("REPLICATION_SYNC_WAIT_TIME_ON_UPGRADE can't be negative.")
+	}
+
+	return uint32(readTimeout), nil
+}
+
+func findPodReadyCondition(pod *corev1.Pod) *corev1.PodCondition {
+	for i, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady {
+			return &pod.Status.Conditions[i]
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
This PR provides two commits with the main goal to improve/fix upgrade of MySQL versions during load:

1. The first commit adds ability to disable CLONE operation. This commit adds the ability to disable CLONE operation during bootstrap of a MySQL node from a cluster with async replication. This behaviour is controlled by the `CLONE_REQUIRED_ON_ASYNC_CLUSTER` boolean environment variable. The CLONE operation exists to clone the primary database instance to the secondary before it   will join the cluster. The operation itself might be expensive in a case of big database and moreover dangerous as it CLONE can't be executed between two MySQL instances with different versions.

2. The second commit adds ability to set time to wait between MySQL pods restart in a case of the underlying StatefulSet was changed. This commit adds ability to set wait time between MySQL instances restart during upgrade of the MySQL cluster. The behaviour is controlled by the integer (in minutes)`REPLICATION_SYNC_WAIT_TIME_ON_UPGRADE` environment variable. The main reason to wait some time between MySQL instances restart during upgrade is that after the secondary instance is restarted it needs some time to sync with the primary. If they are both in sync after the restart of the primary and secondary instances it may lead to the situation when the orchestrator will fail to promote secondary to new primary because of replication lag.